### PR TITLE
Add offset-based timezone configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,5 @@ The following environment variables need to be set in your system:
 To use this bot, send a message to the bot with the description of the food intake. The bot will then respond with the nutrition information (fat, protein, carbohydrates, and calories).
 
 You can also send a date in the format `DD.MM.YY` to get the total nutrition information for that date.
+
+To adjust reminder times, you can set your timezone offset using `/timezone`. The bot expects a number with a plus or minus sign, for example `/timezone +3` for Moscow.


### PR DESCRIPTION
## Summary
- update `/timezone` command to accept numerical offsets
- adjust reminder job to respect stored offset
- document timezone command usage in the README

## Testing
- `pytest -q`
- `flake8` *(fails: command not found, installed and ran; many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68480fcc51e4833285c5756bcb038722